### PR TITLE
Adds react-rails for react components integration

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -16,6 +16,7 @@ gem 'pg'
 gem 'pry-rails'
 gem 'puma'<%= gemfile_requirement('puma') %>
 gem 'rails', '<%= Rails.version %>'
+gem 'react-rails'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-tether'

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -3,5 +3,8 @@
 #= require tether
 #= require bootstrap
 #= require turbolinks
+#= require react
+#= require react_ujs
+#= require components
 #= require_tree .
 

--- a/app/assets/javascripts/components.coffee
+++ b/app/assets/javascripts/components.coffee
@@ -1,0 +1,1 @@
+#= require_tree ./components

--- a/app/assets/javascripts/components/about_page_content.js.jsx.coffee.tt
+++ b/app/assets/javascripts/components/about_page_content.js.jsx.coffee.tt
@@ -1,0 +1,3 @@
+class @AboutPageContent extends React.Component
+  render: ->
+    `<h1>About</h1>`

--- a/app/assets/javascripts/components/landing_page_content.js.jsx.coffee.tt
+++ b/app/assets/javascripts/components/landing_page_content.js.jsx.coffee.tt
@@ -1,0 +1,3 @@
+class @LandingPageContent extends React.Component
+  render: ->
+    `<h1>Landing Page</h1>`

--- a/app/assets/javascripts/components/pricing_page_content.js.jsx.coffee.tt
+++ b/app/assets/javascripts/components/pricing_page_content.js.jsx.coffee.tt
@@ -1,0 +1,3 @@
+class @PricingPageContent extends React.Component
+  render: ->
+    `<h1>Pricing</h1>`

--- a/app/assets/javascripts/template.rb
+++ b/app/assets/javascripts/template.rb
@@ -1,0 +1,10 @@
+copy_file 'app/assets/javascripts/application.coffee'
+run 'rm app/assets/javascripts/application.js'
+
+copy_file 'app/assets/javascripts/components.coffee'
+template 'app/assets/javascripts/components/landing_page_content.js.jsx.coffee.tt'
+template 'app/assets/javascripts/components/pricing_page_content.js.jsx.coffee.tt'
+template 'app/assets/javascripts/components/about_page_content.js.jsx.coffee.tt'
+
+create_file 'app/assets/javascripts/channels/channel.js', ''
+

--- a/app/assets/template.rb
+++ b/app/assets/template.rb
@@ -1,7 +1,5 @@
 
 run "rm app/assets/stylesheets/application.css"
 copy_file 'app/assets/stylesheets/application.scss'
-copy_file 'app/assets/javascripts/application.coffee'
-run 'rm app/assets/javascripts/application.js'
 
-create_file 'app/assets/javascripts/channels/channel.js', ''
+apply('app/assets/javascripts/template.rb')

--- a/app/views/pages/about.haml.tt
+++ b/app/views/pages/about.haml.tt
@@ -1,3 +1,2 @@
 = content_for :page_title, 'About Us'
-%h1
-  About
+= react_component 'AboutPageContent'

--- a/app/views/pages/landing.haml.tt
+++ b/app/views/pages/landing.haml.tt
@@ -1,3 +1,2 @@
 = content_for :page_title, 'Home'
-%h1
-  Landing Page
+= react_component 'LandingPageContent'

--- a/app/views/pages/pricing.haml.tt
+++ b/app/views/pages/pricing.haml.tt
@@ -1,3 +1,2 @@
 = content_for :page_title, 'Pricing'
-%h1
-  Pricing
+= react_component 'PricingPageContent'


### PR DESCRIPTION
Resolves #19 
## Problem

I'd like to have [react](https://facebook.github.io/react/docs/thinking-in-react.html) components available for rapid front end iteration.
## Solution

I've integrated [react-rails](https://github.com/reactjs/react-rails) into the template and the appropriate setup for it to play nicely with sprockets/the asset pipeline.
## Notes

For [react-rails](https://github.com/reactjs/react-rails) to play nicely with turbolinks, make sure that in `app/assets/application.coffee` that the react includes are **AFTER** the line `#= turbolinks`.
