### PR TITLE
Explicitly sets sidekiq testing config

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,8 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
## Problem

Sidekiq::Testing defaults to a `fake` strategy, but it should be more obvious to the template user that this is the case.
## Solution

By explicitly setting `Sidekiq::Testing.fake!` in `spec/rails_helper.rb` it is easily identifiable and configurable for users that want to use [another strategy](https://github.com/mperham/sidekiq/wiki/Testing) like `inline`.
