### PR TITLE
Adds viewport meta tag to application layout

### DIFF
--- a/app/views/layouts/application.haml.tt
+++ b/app/views/layouts/application.haml.tt
@@ -5,6 +5,7 @@
       = '<%= app_name.titleize %>'
       = " | #{yield(:page_title)}" if content_for(:page_title)
 
+    %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1' }
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'


### PR DESCRIPTION
## Problem

Resolves #29 

Upon creation, if the user runs `bundle exec rails s` on the generated app, the pages render scaled on mobile devices.
## Cause

I forgot to add the viewport meta tag to the application layout template.
## Solution

I've added `%meta{ name: 'viewport', content: 'width=device-width, initial-scale=1' }` to the `app/views/layouts/application.haml.tt` template so that the generated layout will force a scale of 1 on mobile browsers.
